### PR TITLE
Jenkins agent image: fix JDK and Maven directories permissions

### DIFF
--- a/jenkins-slaves/ansible/roles/common/tasks/main.yml
+++ b/jenkins-slaves/ansible/roles/common/tasks/main.yml
@@ -89,6 +89,7 @@
   file:
     path: /opt/tools/{{ item }}
     state: directory
+    mode: 0777
   with_items:
     - "{{ jdk_long_versions }}"
     -
@@ -128,6 +129,7 @@
   file:
     path: /opt/tools/apache-maven-{{ item }}
     state: directory
+    mode: 0777
   with_items:
     - "{{ maven_versions }}"
 


### PR DESCRIPTION
Another attempt, in case the permissions will not get overwritten by unarchive role, it should work.