### PR TITLE
Jenkins agent image: fix JDK and Maven directories permissions

### DIFF
--- a/jenkins-slaves/ansible/roles/common/tasks/main.yml
+++ b/jenkins-slaves/ansible/roles/common/tasks/main.yml
@@ -96,14 +96,6 @@
   with_items:
    - "{{ jdk_short_versions }}"
 
-- name: Set permissions on JDK dirs
-  file:
-    path: /opt/tools/{{ item }}
-    state: directory
-    mode: 0777
-  with_items:
-    - "{{ jdk_long_versions }}"
-
 - name: Create JDK symlinks
   file:
     src: /opt/tools/{{ item.0 }}
@@ -113,6 +105,15 @@
   with_together:
   - "{{ jdk_long_versions }}"
   - "{{ jdk_symlink_names }}"
+
+- name: Set permissions on JDK dirs
+  file:
+    path: /opt/tools/{{ item }}
+    owner: root
+    group: root
+    mode: 0777
+  with_items:
+    - "{{ jdk_long_versions }}"
 
 ### Maven ###
 
@@ -133,7 +134,8 @@
 - name: Set permissions on Maven dirs
   file:
     path: /opt/tools/apache-maven-{{ item }}
-    state: directory
+    owner: root
+    group: root
     mode: 0777
   with_items:
     - "{{ maven_versions }}"

--- a/jenkins-slaves/ansible/roles/kie/tasks/main.yml
+++ b/jenkins-slaves/ansible/roles/kie/tasks/main.yml
@@ -116,6 +116,13 @@
     state: link
     mode: 0644
 
+- name: Set permissions on Groovy dir
+  file:
+    path: /opt/tools/groovy-2.4.7
+    owner: root
+    group: root
+    mode: 0777
+
 ### Firefox ###
 
 - name: Download Firefox archives


### PR DESCRIPTION
Moved permissions setting after the symlinks are created in case symlink creation is actually making the trouble.