### PR TITLE
Jenkins agent image: fix symlink permissions change on directories

### DIFF
--- a/jenkins-slaves/ansible/roles/common/tasks/main.yml
+++ b/jenkins-slaves/ansible/roles/common/tasks/main.yml
@@ -92,7 +92,6 @@
     copy: no
     owner: root
     group: root
-    mode: 0777
   with_items:
    - "{{ jdk_short_versions }}"
 
@@ -101,19 +100,11 @@
     src: /opt/tools/{{ item.0 }}
     dest: /opt/tools/{{ item.1 }}
     state: link
+    follow: no
     mode: 0644
   with_together:
   - "{{ jdk_long_versions }}"
   - "{{ jdk_symlink_names }}"
-
-- name: Set permissions on JDK dirs
-  file:
-    path: /opt/tools/{{ item }}
-    owner: root
-    group: root
-    mode: 0777
-  with_items:
-    - "{{ jdk_long_versions }}"
 
 ### Maven ###
 
@@ -133,16 +124,6 @@
     dest: /opt/tools
     owner: root
     group: root
-    mode: 0777
-  with_items:
-    - "{{ maven_versions }}"
-
-- name: Set permissions on Maven dirs
-  file:
-    path: /opt/tools/apache-maven-{{ item }}
-    owner: root
-    group: root
-    mode: 0777
   with_items:
     - "{{ maven_versions }}"
 

--- a/jenkins-slaves/ansible/roles/kie/tasks/main.yml
+++ b/jenkins-slaves/ansible/roles/kie/tasks/main.yml
@@ -114,14 +114,8 @@
     src: /opt/tools/groovy-2.4.7
     dest: /opt/tools/groovy-2.x
     state: link
+    follow: no
     mode: 0644
-
-- name: Set permissions on Groovy dir
-  file:
-    path: /opt/tools/groovy-2.4.7
-    owner: root
-    group: root
-    mode: 0777
 
 ### Firefox ###
 
@@ -205,6 +199,7 @@
     path: /home/jenkins/git-repos/jbpm-console-ng.git
     src: /home/jenkins/git-repos/jbpm-wb.git
     state: link
+    follow: no
     owner: jenkins
     group: jenkins
     mode: 0755

--- a/jenkins-slaves/ansible/roles/rhba/tasks/main.yml
+++ b/jenkins-slaves/ansible/roles/rhba/tasks/main.yml
@@ -60,6 +60,7 @@
     src: /opt/tools/pig/product-files-generator/prod-files-generator-{{pig_version}}-shaded.jar
     dest: /opt/tools/pig/product-files-generator.jar
     state: link
+    follow: no
     mode: 0644
 
 ### Configure Maven ###
@@ -77,6 +78,7 @@
     src: /opt/tools/apache-maven-{{ item }}
     dest: /qa/tools/opt/maven-{{ item }}-prod
     state: link
+    follow: no
     mode: 0644
   with_items:
   - "{{ maven_versions }}"


### PR DESCRIPTION
Do not follow symlinks when setting permissions - should avoid undesired setting permissions on directories which are target of a symlink.